### PR TITLE
Add E2E testing to docs site

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,0 @@
-import antfu from '@antfu/eslint-config'
-
-export default antfu({
-  formatters: true,
-  react: true,
-})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,12 @@
+import antfu from '@antfu/eslint-config'
+import playwright from 'eslint-plugin-playwright'
+
+export default antfu(
+  {
+    formatters: true,
+    react: true,
+  },
+  {
+    ...playwright.configs['flat/recommended'],
+  },
+)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.1.3",
     "eslint-plugin-format": "^0.1.2",
+    "eslint-plugin-playwright": "^1.6.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.9",
     "postcss": "^8.4.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       eslint-plugin-format:
         specifier: ^0.1.2
         version: 0.1.2(eslint@8.57.0)
+      eslint-plugin-playwright:
+        specifier: ^1.6.2
+        version: 1.6.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.0)
@@ -1905,6 +1908,16 @@ packages:
       svelte-eslint-parser:
         optional: true
       vue-eslint-parser:
+        optional: true
+
+  eslint-plugin-playwright@1.6.2:
+    resolution: {integrity: sha512-mraN4Em3b5jLt01q7qWPyLg0Q5v3KAWfJSlEWwldyUXoa7DSPrBR4k6B6LROLqipsG8ndkwWMdjl1Ffdh15tag==}
+    engines: {node: '>=16.6.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
+      eslint-plugin-jest: '>=25'
+    peerDependenciesMeta:
+      eslint-plugin-jest:
         optional: true
 
   eslint-plugin-react-debug@1.8.0:
@@ -6092,6 +6105,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-plugin-playwright@1.6.2(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
+      globals: 13.24.0
 
   eslint-plugin-react-debug@1.8.0(eslint@8.57.0)(typescript@5.5.4):
     dependencies:

--- a/tests/docs/docs.spec.ts
+++ b/tests/docs/docs.spec.ts
@@ -1,0 +1,172 @@
+import { test as base, expect } from '@playwright/test'
+
+import { DocsLayout } from '@root/tests/docs/pom'
+
+const test = base.extend<{ docsLayoutPage: DocsLayout }>({
+  docsLayoutPage: async ({ page }, use) => {
+    const docsLayoutPage = new DocsLayout(page)
+    await docsLayoutPage.goto()
+    await use(docsLayoutPage)
+  },
+})
+
+const DOCS_HOME_PAGE_URL = 'http://localhost:8000/docs'
+const CUHACKING_HACKER_PORTAL_GITHUB_REPOSITORY_URL = 'https://github.com/cuhacking/hackathon'
+const CUHACKING_HACKER_PORTAL_GITHUB_PROJECT_BOARD_URL = 'https://github.com/orgs/cuhacking/projects/4'
+
+test('should contain page title', async ({ docsLayoutPage }) => {
+  await expect(docsLayoutPage.page).toHaveTitle(/Welcome to the Docs/)
+})
+
+test.describe('should contain desktop header elements', {
+  tag: '@smoke',
+}, () => {
+  test('should contain cuHacking logo icon in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
+  })
+
+  test('should take user to docs home page when cuHacking logo icon is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.cuHackingLogoIcon.click()
+    await expect(docsLayoutPage.page).toHaveURL(DOCS_HOME_PAGE_URL)
+  })
+
+  test('should contain cuHacking logo Text in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.cuHackingLogoText).toBeVisible()
+  })
+
+  test('should take user to docs home page when cuHacking logo text is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.cuHackingLogoText.click()
+    await expect(docsLayoutPage.page).toHaveURL(DOCS_HOME_PAGE_URL)
+  })
+
+  test('should contain Landing Page dropdown button in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.landingPageDropdownButton).toBeVisible()
+  })
+
+  test('should contain Landing Page Website link inside Landing Page Dropdown', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.landingPageDropdownButton.click()
+    await expect(docsLayoutPage.landingPageWebsiteLink).toBeVisible()
+  })
+
+  test('should contain Landing Page Website Source link inside Landing Page Dropdown', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.landingPageDropdownButton.click()
+    await expect(docsLayoutPage.landingPageWebsiteSourceLink).toBeVisible()
+  })
+
+  test('should contain Hacker Portal dropdown button in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.hackerPortalDropdownButton).toBeVisible()
+  })
+
+  test('should contain Hacker Portal App link inside Hacker Portal Dropdown', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.hackerPortalLink).toBeVisible()
+  })
+
+  test('should take user to Hacker Portal App when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await docsLayoutPage.hackerPortalLink.click()
+    await expect(docsLayoutPage.page).toHaveURL('http://localhost:8000')
+  })
+
+  test('should contain Hacker Portal Source link inside Hacker Portal Dropdown', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.hackerPortalSourceLink).toBeVisible()
+  })
+
+  test('should take user to Hacker Portal GitHub Repository when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
+    await docsLayoutPage.hackerPortalSourceLink.click()
+    const newPage = await pagePromise
+    await expect(newPage).toHaveURL(CUHACKING_HACKER_PORTAL_GITHUB_REPOSITORY_URL)
+  })
+
+  test('should contain Hacker Portal Project Board link inside Hacker Portal Dropdown', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.hackerPortalProjectBoardLink).toBeVisible()
+  })
+
+  test('should take user to Hacker Portal Project Board when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
+    await docsLayoutPage.hackerPortalProjectBoardLink.click()
+    const newPage = await pagePromise
+    await expect(newPage).toHaveURL(CUHACKING_HACKER_PORTAL_GITHUB_PROJECT_BOARD_URL)
+  })
+
+  test('should contain search bar in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.searchBar).toBeVisible()
+  })
+
+  test('should show search modal when search bar in desktop header is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.searchBar.click()
+    await expect(docsLayoutPage.searchDialog).toBeVisible()
+  })
+
+  test('should contain theme toggle in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.themeToggle).toBeVisible()
+  })
+
+  test('should contain GitHub icon in desktop header', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.gitHubIcon).toBeVisible()
+  })
+
+  test('should take user to cuHacking Hacker Portal GitHub repository when GitHub icon is clicked', async ({ docsLayoutPage }) => {
+    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
+    await docsLayoutPage.gitHubIcon.click()
+    const newPage = await pagePromise
+    await expect(newPage).toHaveURL(CUHACKING_HACKER_PORTAL_GITHUB_REPOSITORY_URL)
+  })
+})
+
+test.describe('should contain desktop sidebar elements', {
+  tag: '@smoke',
+}, () => {
+  test('should contain sidebar toggle in desktop sidebar', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.sideBarToggle).toBeVisible()
+  })
+})
+
+test.describe('should contain floating table of contents elements', {
+  tag: '@smoke',
+}, () => {
+  test('should contain \'Edit on GitHub\' button in floating table of contents', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.editOnGitHubButton).toBeVisible()
+  })
+
+  test('should take user to current docs page file on the cuHacking Hacker Portal GitHub repository when the \'Edit on GitHub\' icon is clicked', async ({ docsLayoutPage }) => {
+    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
+    await docsLayoutPage.editOnGitHubButton.click()
+    const newPage = await pagePromise
+    await expect(newPage).toHaveURL(`${CUHACKING_HACKER_PORTAL_GITHUB_REPOSITORY_URL}/blob/main/src/content/docs/index.mdx`)
+  })
+})
+
+test.describe('should contain docs page elements', {
+  tag: '@smoke',
+}, () => {
+  test('should contain last updated text in docs page footer', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.lastUpdatedText).toBeVisible()
+  })
+})
+
+// TODO: complete test suite for mobile
+test.describe('should contain mobile header elements', {
+  tag: '@smoke',
+}, () => {
+  test('should contain cuHacking Logo Icon in mobile header', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.page.setViewportSize({
+      width: 320,
+      height: 480,
+    })
+    await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
+  })
+
+  test('should contain hamburger icon in mobile header', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.page.setViewportSize({
+      width: 320,
+      height: 480,
+    })
+    await expect(docsLayoutPage.hamburgerIcon).toBeVisible()
+  })
+})

--- a/tests/docs/pom.ts
+++ b/tests/docs/pom.ts
@@ -1,0 +1,77 @@
+import type { Locator, Page } from '@playwright/test'
+
+export class DocsLayout {
+  // Page object
+  readonly page: Page
+
+  // Desktop Header
+  readonly cuHackingLogoIcon: Locator
+  readonly cuHackingLogoText: Locator
+  readonly landingPageDropdownButton: Locator
+  readonly landingPageWebsiteLink: Locator
+  readonly landingPageWebsiteSourceLink: Locator
+  readonly hackerPortalDropdownButton: Locator
+  readonly hackerPortalLink: Locator
+  readonly hackerPortalSourceLink: Locator
+  readonly hackerPortalProjectBoardLink: Locator
+  readonly searchBar: Locator
+  readonly themeToggle: Locator
+  // TODO: add test for language toggle once it's implemented
+  // readonly languageToggle: Locator
+  readonly gitHubIcon: Locator
+
+  // Mobile Header
+  readonly hamburgerIcon: Locator
+
+  // Desktop Sidebar
+  readonly sideBarToggle: Locator
+
+  // Desktop Floating Table of Contents
+  readonly editOnGitHubButton: Locator
+
+  // Docs Page Footer
+  readonly lastUpdatedText: Locator
+
+  // Search Dialog
+  readonly searchDialog: Locator
+
+  constructor(page: Page) {
+    this.page = page
+
+    // Desktop Header
+    this.cuHackingLogoIcon = page.getByRole('img', { name: 'cuHacking logo' })
+    this.cuHackingLogoText = page.getByRole('link', { name: 'cuHacking logo cuHacking' })
+    this.landingPageDropdownButton = page.getByRole('button', { name: 'Landing Page' })
+    this.landingPageWebsiteLink = page.getByRole('dialog').getByRole('link', { name: 'Website' })
+    this.landingPageWebsiteSourceLink = page.getByRole('dialog').getByRole('link', { name: 'Source' })
+    this.hackerPortalDropdownButton = page.getByRole('button', { name: 'Hacker Portal' })
+    this.hackerPortalLink = page.getByRole('dialog').getByRole('link', { name: 'App' })
+    this.hackerPortalSourceLink = page.getByRole('dialog').getByRole('link', { name: 'Source' })
+    this.hackerPortalProjectBoardLink = page.getByRole('dialog').getByRole('link', { name: 'Project Board' })
+    this.searchBar = page.getByRole('button', { name: 'Search ⌘ K' })
+    this.themeToggle = page.getByRole('button', { name: 'Toggle Theme' })
+
+    // TODO: add test for language toggle once it's implemented
+    // this.languageToggle = page.locator('data-testid=languageToggle');
+    this.gitHubIcon = page.locator('div').filter({ hasText: /^Search⌘K$/ }).getByRole('link')
+
+    // Mobile Header
+    this.hamburgerIcon = page.getByLabel('Toggle Sidebar')
+
+    // Desktop Sidebar
+    this.sideBarToggle = page.getByLabel('Collapse Sidebar')
+
+    // Desktop Floating Table of Contents
+    this.editOnGitHubButton = page.getByRole('link', { name: 'Edit on GitHub' })
+
+    // Docs Page Footer
+    this.lastUpdatedText = page.getByRole('article').getByText('Last updated on').last()
+
+    // Search Dialog
+    this.searchDialog = page.getByRole('dialog').getByPlaceholder('Search')
+  }
+
+  async goto() {
+    await this.page.goto('http://localhost:8000/docs')
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,24 +2,31 @@
   "compilerOptions": {
     "incremental": true,
     "target": "es2022",
-
     "jsx": "preserve",
     /* Bundled projects */
-    "lib": ["dom", "dom.iterable", "ES2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
     "moduleDetection": "force",
-
     /* Path Aliases */
     "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
-      "~/*": ["./src/*"],
-      "@/*": ["./src/*"],
-      "@root/*": ["./*"]
+      "~/*": [
+        "./src/*"
+      ],
+      "@/*": [
+        "./src/*"
+      ],
+      "@root/*": [
+        "./*"
+      ]
     },
     "resolveJsonModule": true,
     "allowJs": true,
-
     "checkJs": true,
     /* Strictness */
     "strict": true,
@@ -29,7 +36,11 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "skipLibCheck": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     ".eslintrc.cjs",
@@ -40,7 +51,11 @@
     "**/*.js",
     ".next/types/**/*.ts",
     "postcss.config.cjs",
-    "next.config.mjs"
-, ".map.ts"  ],
-  "exclude": ["node_modules"]
+    "next.config.mjs",
+    ".map.ts",
+    "eslint.config.mjs"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
- Added a basic suite of E2E smoke tests to catch regressions

![image](https://github.com/user-attachments/assets/159ca91f-178e-47a5-99f6-d8ae298f62a3)

You can run the tests using the following commands:
- `npx playwright test` to run them headlessly (boring but very vroom vroom)
- `npx playwright test --headed` to see how easily a robot can replace you (fun but not so vroom vroom)
- `npx playwright test --ui` to selectively run them using the UI mode and see how a robot can replace you but in more detail

The coverage is currently awful and there's still a lot more work to be done. Merging this early to establish patterns that others can build upon, and also so that I can divert attention to more urgent tooling work.